### PR TITLE
Laravel 5.1 / Nested write path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,9 @@ matrix:
 
 before_script:
   - curl -s http://getcomposer.org/installer | php
-  - php composer.phar require "illuminate/support" "$LARAVEL.*"
-  - php composer.phar install --dev
+  - php -n -d extension=json.so composer.phar global require hirak/prestissimo --update-no-dev
+  - php -n -d extension=json.so composer.phar require "illuminate/support" $LARAVEL -vvv
+  - php -n -d extension=json.so composer.phar install --dev
 
 script: phpunit
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,22 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
+  - 5.6
+  - 7.0
+
+env:
+  - LARAVEL=5.1
+  - LARAVEL=5.2
+  - LARAVEL=dev-master
+
+matrix:
+  allow_failures:
+    - env: LARAVEL=dev-master
 
 before_script:
   - curl -s http://getcomposer.org/installer | php
+  - php composer.phar require "illuminate/support" "$LARAVEL.*"
   - php composer.phar install --dev
 
 script: phpunit

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "~5.2",
-        "guzzlehttp/guzzle": "~5.3|~6.0",
+        "illuminate/support": "5.*",
+        "guzzlehttp/guzzle": "5.3|~6.0",
         "imagine/imagine": "0.6.*"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.2"
+        "orchestra/testbench": "3.*"
     },
     "repositories": [
         {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.*",
+        "illuminate/support": ">=5.1",
         "guzzlehttp/guzzle": "5.3|~6.0",
         "imagine/imagine": "0.6.*"
     },

--- a/src/Folklore/Image/ImageManager.php
+++ b/src/Folklore/Image/ImageManager.php
@@ -114,6 +114,11 @@ class ImageManager extends Manager
 
         $path = array();
         $path[] = rtrim($host, '/');
+
+        if ($prefix = $this->app['config']->get('image.write_path')) {
+            $path[] = trim($prefix, '/');
+        }
+
         if (!empty($dir)) {
             $path[] = $dir;
         }

--- a/src/Folklore/Image/ImageManager.php
+++ b/src/Folklore/Image/ImageManager.php
@@ -565,7 +565,7 @@ class ImageManager extends Manager
         // Loop through all the directories files may be uploaded to
         foreach ($dirs as $dir) {
             $dir = rtrim($dir, '/');
-            
+
             // Check that directory exists
             if (!is_dir($dir)) {
                 continue;

--- a/src/Folklore/Image/ImageManager.php
+++ b/src/Folklore/Image/ImageManager.php
@@ -552,8 +552,8 @@ class ImageManager extends Manager
      */
     public function getRealPath($path)
     {
-        if (is_file($path)) {
-            return $path;
+        if (is_file(realpath($path))) {
+            return realpath($path);
         }
         
         //Get directories

--- a/src/Folklore/Image/ImageServe.php
+++ b/src/Folklore/Image/ImageServe.php
@@ -31,26 +31,32 @@ class ImageServe
         $writePath = isset($this->config['write_path']) ? trim($this->config['write_path'], '/') : null;
         $parsedOptions = $parsedPath['options'];
         $imagePath = $parsedPath['path'];
+
         if ($writePath && strpos($imagePath, $writePath) === 0) {
             $imagePath = substr($imagePath, strlen($writePath)+1);
         }
 
         // See if the referenced file exists and is an image
-        if (!($imagePath = $this->image->getRealPath($imagePath))) {
+        if (!($realPath = $this->image->getRealPath($imagePath))) {
             throw new FileMissingException('Image file missing');
         }
 
         // create the destination if it does not exist
         if ($this->config['write_image']) {
+            // make sure the path is relative to the document root
+            if (strpos($realPath, public_path()) === 0) {
+                $imagePath = substr($realPath, strlen(public_path()));
+            }
             $destinationFolder = $writePath ?: dirname($imagePath);
+            $destinationFolder = public_path(trim($writePath, '/') . '/' . ltrim(dirname($imagePath), '/'));
+            
             if (isset($writePath)) {
-                $destinationFolder = public_path(trim($writePath, '/') . '/' . ltrim(dirname($imagePath), '/'));
                 \File::makeDirectory($destinationFolder, 0770, true, true);
             }
         }
 
         // Make sure destination is writeable
-        if ($this->config['write_image'] && !is_writable(dirname($path))) {
+        if ($this->config['write_image'] && !is_writable(dirname($realPath))) {
             throw new Exception('Destination is not writeable');
         }
 
@@ -70,7 +76,7 @@ class ImageServe
         }
 
         //Get the image format
-        $format = $this->image->format($imagePath);
+        $format = $this->image->format($realPath);
 
         //Get the image content
         $saveOptions = array();

--- a/src/Folklore/Image/ImageServe.php
+++ b/src/Folklore/Image/ImageServe.php
@@ -6,13 +6,13 @@ use Folklore\Image\Exception\Exception;
 class ImageServe
 {
     protected $image;
-    
+
     protected $config = [];
-    
+
     public function __construct($image, $config = [])
     {
         $this->image = $image;
-        
+
         $this->config = array_merge([
             'custom_filters_only' => false,
             'write_image' => false,
@@ -21,7 +21,7 @@ class ImageServe
             'options' => []
         ], $config);
     }
-    
+
     public function response($path)
     {
         // Parse the current path
@@ -52,8 +52,14 @@ class ImageServe
 
         //Write the image
         if ($this->config['write_image']) {
-            $destinationFolder = isset($this->config['write_path']) ? $this->config['write_path']:dirname($imagePath);
-            $destinationPath = rtrim($destinationFolder, '/').'/'.basename($path);
+            $destinationFolder = isset($this->config['write_path']) ? $this->config['write_path'] : dirname($imagePath);
+
+            if (isset($this->config['write_path'])) {
+                $destinationFolder = public_path(trim($this->config['write_path'], '/') . '/' . ltrim(dirname($imagePath), '/'));
+                \File::makeDirectory($destinationFolder, 0770, true, true);
+            }
+
+            $destinationPath = rtrim($destinationFolder, '/') . '/' . basename($path);
             $image->save($destinationPath);
         }
 
@@ -66,7 +72,7 @@ class ImageServe
         if ($format === 'jpeg') {
             $saveOptions['jpeg_quality'] = $quality;
         } elseif ($format === 'png') {
-            $saveOptions['png_compression_level'] = round($quality/100 * 9);
+            $saveOptions['png_compression_level'] = round($quality / 100 * 9);
         }
         $contents = $image->get($format, $saveOptions);
 
@@ -74,7 +80,7 @@ class ImageServe
         $mime = $this->image->getMimeFromFormat($format);
         $response = response()->make($contents, 200);
         $response->header('Content-Type', $mime);
-        
+
         return $response;
     }
 }

--- a/tests/ImageServeTestCase.php
+++ b/tests/ImageServeTestCase.php
@@ -33,45 +33,47 @@ class ImageServeTestCase extends TestCase
     public function testServeWriteImage()
     {
         $this->app['config']->set('image.write_image', true);
-        
+
         $url = $this->image->url($this->imagePath, 300, 300, [
             'crop' => true
         ]);
-        
+
         $response = $this->call('GET', $url);
 
         $this->assertTrue($response->isOk());
 
         $imagePath = $this->app['path.public'].'/'.basename($url);
         $this->assertFileExists($imagePath);
-        
+
         $sizeManipulated = getimagesize($imagePath);
         $this->assertEquals($sizeManipulated[0], 300);
         $this->assertEquals($sizeManipulated[1], 300);
-        
+
         $this->app['config']->set('image.write_image', false);
     }
 
     public function testServeWriteImagePath()
     {
-        $customPath = $this->app['path.public'].'/custom';
+        $customPath = 'custom';
+
         $this->app['config']->set('image.write_image', true);
         $this->app['config']->set('image.write_path', $customPath);
-        
+
         $url = $this->image->url($this->imagePath, 300, 300, [
             'crop' => true
         ]);
+
         $response = $this->call('GET', $url);
 
         $this->assertTrue($response->isOk());
 
-        $imagePath = $customPath.'/'.basename($url);
+        $imagePath = public_path($customPath.'/'.basename($url));
         $this->assertFileExists($imagePath);
-        
+
         $sizeManipulated = getimagesize($imagePath);
         $this->assertEquals($sizeManipulated[0], 300);
         $this->assertEquals($sizeManipulated[1], 300);
-        
+
         $this->app['config']->set('image.write_image', false);
         $this->app['config']->set('image.write_path', null);
     }


### PR DESCRIPTION
Hello, this PR will probably never be merged, but I'd still like to propose it.

1. Lowers the requirement to Laravel 5.0. This is probably not right, the version should be >= 5.1. Laravel 5.1 is an LTS and deserves to be supported. Your code works perfectly on 5.1 (when you switched to 5.2 you just removed classes that were already deprecated in the 5.1). There's no need to pin illuminate/support and orchestral in the composer.json as Composer will choose by itself the right version of both.

2. Write path is now a nested folder, so you can enjoy the same caching benefits as before. Set it to `thumbs` and `/thumbs/uploads/posts/example-image(10x10-crop).jpg` will create the crop of `/uploads/posts/example.jpg`. This is done to have finer control in your ,htaccess and system permissions (sometimes I use laravel-image to resize not just uploads, but also website assets that lie in non-writable folders.