### PR TITLE
fix: check write permissions on the right folder

### DIFF
--- a/src/Folklore/Image/ImageManager.php
+++ b/src/Folklore/Image/ImageManager.php
@@ -225,9 +225,14 @@ class ImageManager extends Manager
      */
     public function serve($path, $config = array())
     {
+        //Use user supplied quality or the config value
+        $quality = array_get($config, 'quality', $this->app['config']['image.quality']);
+        //if nothing works fallback to the hardcoded value
+        $quality = $quality ?: $this->defaultOptions['quality'];
+
         //Merge config with defaults
         $config = array_merge(array(
-            'quality' => array_get($config, 'quality', $this->defaultOptions['quality']),
+            'quality' => $quality,
             'custom_filters_only' => $this->app['config']['image.serve_custom_filters_only'],
             'write_image' => $this->app['config']['image.write_image'],
             'write_path' => $this->app['config']['image.write_path']

--- a/src/Folklore/Image/ImageServe.php
+++ b/src/Folklore/Image/ImageServe.php
@@ -53,12 +53,13 @@ class ImageServe
             if (isset($writePath)) {
                 \File::makeDirectory($destinationFolder, 0770, true, true);
             }
+
+            // Make sure destination is writeable
+            if (!is_writable(dirname($destinationFolder))) {
+                throw new Exception('Destination is not writeable');
+            }
         }
 
-        // Make sure destination is writeable
-        if ($this->config['write_image'] && !is_writable(dirname($realPath))) {
-            throw new Exception('Destination is not writeable');
-        }
 
         // Merge all options with the following priority:
         // Options passed as an argument to the serve method


### PR DESCRIPTION
In the last PR the permissions check was made on the wrong folder. 

My fault, apologies.

