### PR TITLE
"Write Path" direcotry permissions

### DIFF
--- a/src/Folklore/Image/ImageServe.php
+++ b/src/Folklore/Image/ImageServe.php
@@ -51,7 +51,7 @@ class ImageServe
             $destinationFolder = public_path(trim($writePath, '/') . '/' . ltrim(dirname($imagePath), '/'));
             
             if (isset($writePath)) {
-                \File::makeDirectory($destinationFolder, 0770, true, true);
+                \File::makeDirectory($destinationFolder, 0755, true, true);
             }
 
             // Make sure destination is writeable

--- a/src/Folklore/Image/ImageServe.php
+++ b/src/Folklore/Image/ImageServe.php
@@ -51,7 +51,7 @@ class ImageServe
             $destinationFolder = public_path(trim($writePath, '/') . '/' . ltrim(dirname($imagePath), '/'));
             
             if (isset($writePath)) {
-                \File::makeDirectory($destinationFolder, 0755, true, true);
+                \File::makeDirectory($destinationFolder, 0775, true, true);
             }
 
             // Make sure destination is writeable


### PR DESCRIPTION
Direcotry specified on ```write_path``` setting is created with ```0770``` permissions, which is causing issues on some Plesk installations. File is created at first request, but can't be served on subsequent requests.

This PR is changing permissions to default 0775, so that webserver user and group can read and write and others can read.