### PR TITLE
change permission of created directories

### DIFF
--- a/src/Folklore/Image/ImageServe.php
+++ b/src/Folklore/Image/ImageServe.php
@@ -51,7 +51,7 @@ class ImageServe
             $destinationFolder = public_path(trim($writePath, '/') . '/' . ltrim(dirname($imagePath), '/'));
             
             if (isset($writePath)) {
-                \File::makeDirectory($destinationFolder, 0770, true, true);
+                \File::makeDirectory($destinationFolder, 0775, true, true);
             }
 
             // Make sure destination is writeable


### PR DESCRIPTION
directories must have r & x permission

in some control panel software like Plesk with permission 0770 web server user can't access the file because can't access folder (the directory owner user is someone else), so the permission must be 0775