### PR TITLE
Added support for laravel 5.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ env:
     - ILLUMINATE_VERSION=5.4.* PHPUNIT_VERSION=~5.7
     - ILLUMINATE_VERSION=5.5.* PHPUNIT_VERSION=~6.0
     - ILLUMINATE_VERSION=5.6.* PHPUNIT_VERSION=~7.0
-    - ILLUMINATE_VERSION=5.7.* PHPUNIT_VERSION=~7.0 COVERAGE=true
+    - ILLUMINATE_VERSION=5.7.* PHPUNIT_VERSION=~7.0
+    - ILLUMINATE_VERSION=5.8.* PHPUNIT_VERSION=~7.0 COVERAGE=true
 
 matrix:
     # For each PHP version we exclude the coverage env, except for PHP 7.1
@@ -34,19 +35,25 @@ matrix:
         - php: 5.5
           env: ILLUMINATE_VERSION=5.6.* PHPUNIT_VERSION=~7.0
         - php: 5.5
-          env: ILLUMINATE_VERSION=5.7.* PHPUNIT_VERSION=~7.0 COVERAGE=true
+          env: ILLUMINATE_VERSION=5.7.* PHPUNIT_VERSION=~7.0
+        - php: 5.5
+          env: ILLUMINATE_VERSION=5.8.* PHPUNIT_VERSION=~7.0 COVERAGE=true
         # Don't test Laravel 5.5 and up on PHP 5.6
         - php: 5.6
           env: ILLUMINATE_VERSION=5.5.* PHPUNIT_VERSION=~6.0
         - php: 5.6
           env: ILLUMINATE_VERSION=5.6.* PHPUNIT_VERSION=~7.0
         - php: 5.6
-          env: ILLUMINATE_VERSION=5.7.* PHPUNIT_VERSION=~7.0 COVERAGE=true
+          env: ILLUMINATE_VERSION=5.7.* PHPUNIT_VERSION=~7.0
+        - php: 5.6
+          env: ILLUMINATE_VERSION=5.8.* PHPUNIT_VERSION=~7.0 COVERAGE=true
         # Test Laravel 5.5 and down on PHP 7.0
         - php: 7.0
           env: ILLUMINATE_VERSION=5.6.* PHPUNIT_VERSION=~7.0
         - php: 7.0
-          env: ILLUMINATE_VERSION=5.7.* PHPUNIT_VERSION=~7.0 COVERAGE=true
+          env: ILLUMINATE_VERSION=5.7.* PHPUNIT_VERSION=~7.0
+        - php: 7.0
+          env: ILLUMINATE_VERSION=5.8.* PHPUNIT_VERSION=~7.0 COVERAGE=true
         # Test only Laravel 5.4 and up on PHP 7.1
         - php: 7.1
           env: ILLUMINATE_VERSION=5.1.* PHPUNIT_VERSION=~4.0

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
-        "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*",
+        "php": "^7.1.3",
+        "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*",
         "guzzlehttp/guzzle": "5.3|~6.0",
         "imagine/imagine": "0.6.*"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",
-        "orchestra/testbench": "3.1.*|3.2.*|3.3.*|3.4.*|3.5.*|3.6.*|3.7.*",
+        "orchestra/testbench": "3.1.*|3.2.*|3.3.*|3.4.*|3.5.*|3.6.*|3.7.*|3.8.*",
         "mockery/mockery": "0.9.*|1.0.*",
         "phpunit/phpunit": "~4.0|~4.1|~5.4|~5.7|~6.0|~7.0",
         "php-coveralls/php-coveralls": "^2.1"

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,7 @@ This package also provides some common filters ready to use ([more on this](http
  5.0.x    | 0.2.x
  5.1.x    | 0.3.x
  5.2.x    | 0.3.x
+ 5.8.x    | 0.4.x
 
 ## Installation
 

--- a/tests/ImageProxyTestCase.php
+++ b/tests/ImageProxyTestCase.php
@@ -11,22 +11,22 @@ class ImageProxyTestCase extends TestCase
     protected $imageSize;
     protected $imageSmallSize;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
-        
+
         $this->image = $this->app['image'];
         $this->imageSize = getimagesize(public_path().$this->imagePath);
         $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $customPath = $this->app['path.public'].'/custom';
         $this->app['config']->set('image.write_path', $customPath);
-        
+
         $this->image->deleteManipulated($this->imagePath);
-        
+
         parent::tearDown();
     }
 
@@ -37,13 +37,13 @@ class ImageProxyTestCase extends TestCase
         ]);
         $response = $this->call('GET', $url);
         $this->assertTrue($response->isOk());
-        
+
         $image = imagecreatefromstring($response->getContent());
         $this->assertTrue($image !== false);
-        
+
         $this->assertEquals(imagesx($image), 300);
         $this->assertEquals(imagesy($image), 300);
-        
+
         imagedestroy($image);
     }
 
@@ -52,22 +52,22 @@ class ImageProxyTestCase extends TestCase
         $this->app['config']->set('image.host', '/proxy/http://placehold.it/');
         $this->app['config']->set('image.proxy_filesystem', null);
         $this->app['config']->set('image.proxy_route_pattern', '^(.*)$');
-        
+
         $url = $this->image->url('/640x480.png', 300, 300, [
             'crop' => true
         ]);
         $response = $this->call('GET', $url);
         $this->assertTrue($response->isOk());
-        
+
         $image = imagecreatefromstring($response->getContent());
         $this->assertTrue($image !== false);
-        
+
         $this->assertEquals(imagesx($image), 300);
         $this->assertEquals(imagesy($image), 300);
-        
+
         imagedestroy($image);
     }
-    
+
     /**
      * Define environment setup.
      *
@@ -77,22 +77,22 @@ class ImageProxyTestCase extends TestCase
     protected function getEnvironmentSetUp($app)
     {
         $app->instance('path.public', __DIR__.'/fixture');
-        
+
         $app['config']->set('image.host', '/proxy');
         $app['config']->set('image.serve', false);
         $app['config']->set('image.proxy', true);
         $app['config']->set('image.proxy_route', '/proxy/{image_proxy_pattern}');
         $app['config']->set('image.proxy_filesystem', 'image_testbench');
         $app['config']->set('image.proxy_cache_filesystem', null);
-        
+
         $app['config']->set('filesystems.default', 'image_testbench');
         $app['config']->set('filesystems.cloud', 'image_testbench');
-        
+
         $app['config']->set('filesystems.disks.image_testbench', [
             'driver' => 'local',
             'root' => __DIR__.'/fixture'
         ]);
-        
+
         $app['config']->set('filesystems.disks.image_testbench_cache', [
             'driver' => 'local',
             'root' => __DIR__.'/fixture/cache'

--- a/tests/ImageServeTestCase.php
+++ b/tests/ImageServeTestCase.php
@@ -11,7 +11,7 @@ class ImageServeTestCase extends TestCase
     protected $imageSize;
     protected $imageSmallSize;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -20,7 +20,7 @@ class ImageServeTestCase extends TestCase
         $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $customPath = $this->app['path.public'].'/custom';
         $this->app['config']->set('image.write_path', $customPath);

--- a/tests/ImageTestCase.php
+++ b/tests/ImageTestCase.php
@@ -11,22 +11,22 @@ class ImageTestCase extends TestCase
     protected $imageSize;
     protected $imageSmallSize;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
-        
+
         $this->image = $this->app['image'];
         $this->imageSize = getimagesize(public_path().$this->imagePath);
         $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $customPath = $this->app['path.public'].'/custom';
         $this->app['config']->set('image.write_path', $customPath);
-        
+
         $this->image->deleteManipulated($this->imagePath);
-        
+
         parent::tearDown();
     }
 
@@ -78,7 +78,7 @@ class ImageTestCase extends TestCase
 
         }
     }
-    
+
     /**
      * Define environment setup.
      *


### PR DESCRIPTION
Not sure how it should be done correctly since orchestra added return type hint in 3.8 and also Laravel requires php7.1+

Probably should be released as separate version(0.4.*) with breaking changes.