### PR TITLE
Migration to Laravel 5.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
     - ${TRAVIS_BUILD_DIR}/travis/extension-cache
 
 php:
-    - 7.0
     - 7.1
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ cache:
     - ${TRAVIS_BUILD_DIR}/travis/extension-cache
 
 php:
-    - 5.5
-    - 5.6
     - 7.0
     - 7.1
 
@@ -26,28 +24,6 @@ env:
 matrix:
     # For each PHP version we exclude the coverage env, except for PHP 7.1
     exclude:
-        # Test only Laravel 5.1 and 5.2 on PHP 5.5
-        - php: 5.5
-          env: ILLUMINATE_VERSION=5.3.* PHPUNIT_VERSION=~5.0
-        - php: 5.5
-          env: ILLUMINATE_VERSION=5.4.* PHPUNIT_VERSION=~5.7
-        - php: 5.5
-          env: ILLUMINATE_VERSION=5.5.* PHPUNIT_VERSION=~6.0
-        - php: 5.5
-          env: ILLUMINATE_VERSION=5.6.* PHPUNIT_VERSION=~7.0
-        - php: 5.5
-          env: ILLUMINATE_VERSION=5.7.* PHPUNIT_VERSION=~7.0
-        - php: 5.5
-          env: ILLUMINATE_VERSION=5.8.* PHPUNIT_VERSION=~7.0 COVERAGE=true
-        # Don't test Laravel 5.5 and up on PHP 5.6
-        - php: 5.6
-          env: ILLUMINATE_VERSION=5.5.* PHPUNIT_VERSION=~6.0
-        - php: 5.6
-          env: ILLUMINATE_VERSION=5.6.* PHPUNIT_VERSION=~7.0
-        - php: 5.6
-          env: ILLUMINATE_VERSION=5.7.* PHPUNIT_VERSION=~7.0
-        - php: 5.6
-          env: ILLUMINATE_VERSION=5.8.* PHPUNIT_VERSION=~7.0 COVERAGE=true
         # Test Laravel 5.5 and down on PHP 7.0
         - php: 7.0
           env: ILLUMINATE_VERSION=5.6.* PHPUNIT_VERSION=~7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,9 @@ env:
     - ILLUMINATE_VERSION=5.4.* PHPUNIT_VERSION=~5.7
     - ILLUMINATE_VERSION=5.5.* PHPUNIT_VERSION=~6.0
     - ILLUMINATE_VERSION=5.6.* PHPUNIT_VERSION=~7.0
-    - ILLUMINATE_VERSION=5.7.* PHPUNIT_VERSION=~7.0 COVERAGE=true
+    - ILLUMINATE_VERSION=5.7.* PHPUNIT_VERSION=~7.0
+    - ILLUMINATE_VERSION=5.8.* PHPUNIT_VERSION=~7.0 COVERAGE=true
+
 
 matrix:
     # For each PHP version we exclude the coverage env, except for PHP 7.1
@@ -34,19 +36,25 @@ matrix:
         - php: 5.5
           env: ILLUMINATE_VERSION=5.6.* PHPUNIT_VERSION=~7.0
         - php: 5.5
-          env: ILLUMINATE_VERSION=5.7.* PHPUNIT_VERSION=~7.0 COVERAGE=true
+          env: ILLUMINATE_VERSION=5.7.* PHPUNIT_VERSION=~7.0
+        - php: 5.5
+          env: ILLUMINATE_VERSION=5.8.* PHPUNIT_VERSION=~7.0 COVERAGE=true
         # Don't test Laravel 5.5 and up on PHP 5.6
         - php: 5.6
           env: ILLUMINATE_VERSION=5.5.* PHPUNIT_VERSION=~6.0
         - php: 5.6
           env: ILLUMINATE_VERSION=5.6.* PHPUNIT_VERSION=~7.0
         - php: 5.6
-          env: ILLUMINATE_VERSION=5.7.* PHPUNIT_VERSION=~7.0 COVERAGE=true
+          env: ILLUMINATE_VERSION=5.7.* PHPUNIT_VERSION=~7.0
+        - php: 5.6
+          env: ILLUMINATE_VERSION=5.8.* PHPUNIT_VERSION=~7.0 COVERAGE=true
         # Test Laravel 5.5 and down on PHP 7.0
         - php: 7.0
           env: ILLUMINATE_VERSION=5.6.* PHPUNIT_VERSION=~7.0
         - php: 7.0
-          env: ILLUMINATE_VERSION=5.7.* PHPUNIT_VERSION=~7.0 COVERAGE=true
+          env: ILLUMINATE_VERSION=5.7.* PHPUNIT_VERSION=~7.0
+        - php: 7.0
+          env: ILLUMINATE_VERSION=5.8.* PHPUNIT_VERSION=~7.0 COVERAGE=true
         # Test only Laravel 5.4 and up on PHP 7.1
         - php: 7.1
           env: ILLUMINATE_VERSION=5.1.* PHPUNIT_VERSION=~4.0

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": ">=5.5.9",
         "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*",
         "guzzlehttp/guzzle": "5.3|~6.0",
         "imagine/imagine": "0.6.*"

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "folklore/image",
     "description": "Image manipulation library for Laravel 5 based on Imagine and inspired by Croppa for easy url based manipulation",
     "keywords": ["laravel","image","imagick","gd","imagine","watermark","gmagick","thumbnail"],
-    "homepage": "http://github.com/Folkloreatelier/laravel-image",
+    "homepage": "https://github.com/folkloreinc/laravel-image",
     "license": "MIT",
     "authors": [
         {
@@ -18,14 +18,14 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
-        "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*",
+        "php": "^7.1.3",
+        "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*",
         "guzzlehttp/guzzle": "5.3|~6.0",
         "imagine/imagine": "0.6.*"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",
-        "orchestra/testbench": "3.1.*|3.2.*|3.3.*|3.4.*|3.5.*|3.6.*|3.7.*",
+        "orchestra/testbench": "3.1.*|3.2.*|3.3.*|3.4.*|3.5.*|3.6.*|3.7.*|3.8.*",
         "mockery/mockery": "0.9.*|1.0.*",
         "phpunit/phpunit": "~4.0|~4.1|~5.4|~5.7|~6.0|~7.0",
         "php-coveralls/php-coveralls": "^2.1"

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 Laravel Image is an image manipulation package for Laravel 4 and 5 based on the [PHP Imagine library](https://github.com/avalanche123/Imagine). It is inspired by [Croppa](https://github.com/BKWLD/croppa) as it can use specially formatted urls to do the manipulations. It supports basic image manipulations such as resize, crop, rotation and flip. It also supports effects such as negative, grayscale, gamma, colorize and blur. You can also define custom filters for greater flexibility.
 
 [![Latest Stable Version](https://poser.pugx.org/folklore/image/v/stable.svg)](https://packagist.org/packages/folklore/image)
-[![Build Status](https://travis-ci.org/Folkloreatelier/laravel-image.png?branch=master)](https://travis-ci.org/Folkloreatelier/laravel-image)
+[![Build Status](https://travis-ci.org/leknoppix/laravel-image.png?branch=master)](https://travis-ci.org/leknoppix/laravel-image)
 [![Total Downloads](https://poser.pugx.org/folklore/image/downloads.svg)](https://packagist.org/packages/folklore/image)
 
 The main difference between this package and other image manipulation libraries is that you can use parameters directly in the url to manipulate the image. A manipulated version of the image is then saved in the same path as the original image, **creating a static version of the file and bypassing PHP for all future requests**.

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,7 @@ This package also provides some common filters ready to use ([more on this](http
  5.0.x    | 0.2.x
  5.1.x    | 0.3.x
  5.2.x    | 0.3.x
+ 5.8.x    | 0.4.x
 
 ## Installation
 

--- a/tests/ImageProxyTestCase.php
+++ b/tests/ImageProxyTestCase.php
@@ -1,4 +1,6 @@
-<?php namespace Folklore\Image\Tests;
+<?php
+declare(strict_types=1);
+namespace Folklore\Image\Tests;
 
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Folklore\Image\Exception\FormatException;
@@ -13,21 +15,6 @@ class ImageProxyTestCase extends TestCase
     protected $imageSmallSize;
 
 
-        /**
-         * @requires PHP 7.1
-         */
-        public function setUp():void
-        {
-            parent::setUp();
-            
-            $this->image = $this->app['image'];
-            $this->imageSize = getimagesize(public_path().$this->imagePath);
-            $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
-        }
-
-        /**
-         * @requires PHP 5.3
-         */
         public function setUp()
         {
             parent::setUp();
@@ -37,21 +24,7 @@ class ImageProxyTestCase extends TestCase
             $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
         }
 
-        /**
-         * @requires PHP 5.3
-         */
         public function tearDown()
-        {
-            $customPath = $this->app['path.public'].'/custom';
-            $this->app['config']->set('image.write_path', $customPath);
-            $this->image->deleteManipulated($this->imagePath);
-            parent::tearDown();
-        }
-
-        /**
-         * @requires PHP 7.1
-         */
-        public function tearDown():void
         {
             $customPath = $this->app['path.public'].'/custom';
             $this->app['config']->set('image.write_path', $customPath);

--- a/tests/ImageProxyTestCase.php
+++ b/tests/ImageProxyTestCase.php
@@ -6,37 +6,16 @@ use Orchestra\Testbench\TestCase;
 
 class ImageProxyTestCase extends TestCase
 {
+  
     protected $imagePath = '/image.jpg';
     protected $imageSmallPath = '/image_small.jpg';
     protected $imageSize;
     protected $imageSmallSize;
 
-    if ((!defined('PHP_VERSION_ID')) {
-        $version = explode('.',PHP_VERSION);
-        define('PHP_VERSION_ID', ($version[0] * 10000 + $version[1] * 100 + $version[2]));
-    }
 
-    if(PHP_VERSION_ID <= 70000)
-    {
-        public function setUp()
-        {
-            parent::setUp();
-            
-            $this->image = $this->app['image'];
-            $this->imageSize = getimagesize(public_path().$this->imagePath);
-            $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
-        }
-
-        public function tearDown()
-        {
-            $customPath = $this->app['path.public'].'/custom';
-            $this->app['config']->set('image.write_path', $customPath);
-            
-            $this->image->deleteManipulated($this->imagePath);
-            
-            parent::tearDown();
-        }
-    }else{
+        /**
+         * @requires PHP 7.1
+         */
         public function setUp():void
         {
             parent::setUp();
@@ -46,17 +25,40 @@ class ImageProxyTestCase extends TestCase
             $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
         }
 
+        /**
+         * @requires PHP 5.3
+         */
+        public function setUp()
+        {
+            parent::setUp();
+            
+            $this->image = $this->app['image'];
+            $this->imageSize = getimagesize(public_path().$this->imagePath);
+            $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
+        }
+
+        /**
+         * @requires PHP 5.3
+         */
+        public function tearDown()
+        {
+            $customPath = $this->app['path.public'].'/custom';
+            $this->app['config']->set('image.write_path', $customPath);
+            $this->image->deleteManipulated($this->imagePath);
+            parent::tearDown();
+        }
+
+        /**
+         * @requires PHP 7.1
+         */
         public function tearDown():void
         {
             $customPath = $this->app['path.public'].'/custom';
             $this->app['config']->set('image.write_path', $customPath);
-            
             $this->image->deleteManipulated($this->imagePath);
-            
             parent::tearDown();
         }
-    }
-
+    
     public function testProxy()
     {
         $url = $this->image->url($this->imagePath, 300, 300, [

--- a/tests/ImageProxyTestCase.php
+++ b/tests/ImageProxyTestCase.php
@@ -11,23 +11,50 @@ class ImageProxyTestCase extends TestCase
     protected $imageSize;
     protected $imageSmallSize;
 
-    public function setUp()
-    {
-        parent::setUp();
-        
-        $this->image = $this->app['image'];
-        $this->imageSize = getimagesize(public_path().$this->imagePath);
-        $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
+    if ((!defined('PHP_VERSION_ID')) {
+        $version = explode('.',PHP_VERSION);
+        define('PHP_VERSION_ID', ($version[0] * 10000 + $version[1] * 100 + $version[2]));
     }
 
-    public function tearDown()
+    if(PHP_VERSION_ID <= 70000)
     {
-        $customPath = $this->app['path.public'].'/custom';
-        $this->app['config']->set('image.write_path', $customPath);
-        
-        $this->image->deleteManipulated($this->imagePath);
-        
-        parent::tearDown();
+        public function setUp()
+        {
+            parent::setUp();
+            
+            $this->image = $this->app['image'];
+            $this->imageSize = getimagesize(public_path().$this->imagePath);
+            $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
+        }
+
+        public function tearDown()
+        {
+            $customPath = $this->app['path.public'].'/custom';
+            $this->app['config']->set('image.write_path', $customPath);
+            
+            $this->image->deleteManipulated($this->imagePath);
+            
+            parent::tearDown();
+        }
+    }else{
+        public function setUp():void
+        {
+            parent::setUp();
+            
+            $this->image = $this->app['image'];
+            $this->imageSize = getimagesize(public_path().$this->imagePath);
+            $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
+        }
+
+        public function tearDown():void
+        {
+            $customPath = $this->app['path.public'].'/custom';
+            $this->app['config']->set('image.write_path', $customPath);
+            
+            $this->image->deleteManipulated($this->imagePath);
+            
+            parent::tearDown();
+        }
     }
 
     public function testProxy()

--- a/tests/ImageProxyTestCase.php
+++ b/tests/ImageProxyTestCase.php
@@ -11,7 +11,7 @@ class ImageProxyTestCase extends TestCase
     protected $imageSize;
     protected $imageSmallSize;
 
-    public function setUp():void
+    public function setUp()
     {
         parent::setUp();
         
@@ -20,7 +20,7 @@ class ImageProxyTestCase extends TestCase
         $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
     }
 
-    public function tearDown():void
+    public function tearDown()
     {
         $customPath = $this->app['path.public'].'/custom';
         $this->app['config']->set('image.write_path', $customPath);

--- a/tests/ImageProxyTestCase.php
+++ b/tests/ImageProxyTestCase.php
@@ -15,7 +15,7 @@ class ImageProxyTestCase extends TestCase
     protected $imageSmallSize;
 
 
-        public function setUp(): void
+        public function setUp():void
         {
             parent::setUp();
             
@@ -24,7 +24,7 @@ class ImageProxyTestCase extends TestCase
             $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
         }
 
-        public function tearDown(): void
+        public function tearDown():void
         {
             $customPath = $this->app['path.public'].'/custom';
             $this->app['config']->set('image.write_path', $customPath);

--- a/tests/ImageProxyTestCase.php
+++ b/tests/ImageProxyTestCase.php
@@ -11,7 +11,7 @@ class ImageProxyTestCase extends TestCase
     protected $imageSize;
     protected $imageSmallSize;
 
-    public function setUp()
+    public function setUp():void
     {
         parent::setUp();
         
@@ -20,7 +20,7 @@ class ImageProxyTestCase extends TestCase
         $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
     }
 
-    public function tearDown()
+    public function tearDown():void
     {
         $customPath = $this->app['path.public'].'/custom';
         $this->app['config']->set('image.write_path', $customPath);

--- a/tests/ImageProxyTestCase.php
+++ b/tests/ImageProxyTestCase.php
@@ -15,7 +15,7 @@ class ImageProxyTestCase extends TestCase
     protected $imageSmallSize;
 
 
-        public function setUp()
+        public function setUp(): void
         {
             parent::setUp();
             
@@ -24,7 +24,7 @@ class ImageProxyTestCase extends TestCase
             $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
         }
 
-        public function tearDown()
+        public function tearDown(): void
         {
             $customPath = $this->app['path.public'].'/custom';
             $this->app['config']->set('image.write_path', $customPath);

--- a/tests/ImageServeTestCase.php
+++ b/tests/ImageServeTestCase.php
@@ -1,4 +1,6 @@
-<?php namespace Folklore\Image\Tests;
+<?php
+declare(strict_types=1);
+namespace Folklore\Image\Tests;
 
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Folklore\Image\Exception\FormatException;
@@ -11,9 +13,7 @@ class ImageServeTestCase extends TestCase
     protected $imageSize;
     protected $imageSmallSize;
 
-        /**
-         * @requires PHP 5.3
-         */
+        
         public function setUp()
         {
             parent::setUp();
@@ -23,9 +23,6 @@ class ImageServeTestCase extends TestCase
             $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
         }
 
-        /**
-         * @requires PHP 5.3
-         */
         public function tearDown()
         {
             $customPath = $this->app['path.public'].'/custom';
@@ -36,30 +33,6 @@ class ImageServeTestCase extends TestCase
             parent::tearDown();
         }
         
-        /**
-         * @requires PHP 7.1
-         */
-        public function setUp():void
-        {
-            parent::setUp();
-
-            $this->image = $this->app['image'];
-            $this->imageSize = getimagesize(public_path().$this->imagePath);
-            $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
-        }
-        /**
-         * @requires PHP 7.1
-         */
-        public function tearDown():void
-        {
-            $customPath = $this->app['path.public'].'/custom';
-            $this->app['config']->set('image.write_path', $customPath);
-
-            $this->image->deleteManipulated($this->imagePath);
-
-            parent::tearDown();
-        }
-    }
     public function testServeWriteImage()
     {
         $this->app['config']->set('image.write_image', true);

--- a/tests/ImageServeTestCase.php
+++ b/tests/ImageServeTestCase.php
@@ -11,7 +11,7 @@ class ImageServeTestCase extends TestCase
     protected $imageSize;
     protected $imageSmallSize;
 
-    public function setUp():void
+    public function setUp()
     {
         parent::setUp();
 
@@ -20,7 +20,7 @@ class ImageServeTestCase extends TestCase
         $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
     }
 
-    public function tearDown():void
+    public function tearDown()
     {
         $customPath = $this->app['path.public'].'/custom';
         $this->app['config']->set('image.write_path', $customPath);

--- a/tests/ImageServeTestCase.php
+++ b/tests/ImageServeTestCase.php
@@ -11,7 +11,7 @@ class ImageServeTestCase extends TestCase
     protected $imageSize;
     protected $imageSmallSize;
 
-    public function setUp()
+    public function setUp():void
     {
         parent::setUp();
 
@@ -20,7 +20,7 @@ class ImageServeTestCase extends TestCase
         $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
     }
 
-    public function tearDown()
+    public function tearDown():void
     {
         $customPath = $this->app['path.public'].'/custom';
         $this->app['config']->set('image.write_path', $customPath);

--- a/tests/ImageServeTestCase.php
+++ b/tests/ImageServeTestCase.php
@@ -14,7 +14,7 @@ class ImageServeTestCase extends TestCase
     protected $imageSmallSize;
 
         
-        public function setUp()
+        public function setUp(): void
         {
             parent::setUp();
 
@@ -23,7 +23,7 @@ class ImageServeTestCase extends TestCase
             $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
         }
 
-        public function tearDown()
+        public function tearDown(): void
         {
             $customPath = $this->app['path.public'].'/custom';
             $this->app['config']->set('image.write_path', $customPath);
@@ -32,7 +32,7 @@ class ImageServeTestCase extends TestCase
 
             parent::tearDown();
         }
-        
+
     public function testServeWriteImage()
     {
         $this->app['config']->set('image.write_image', true);

--- a/tests/ImageServeTestCase.php
+++ b/tests/ImageServeTestCase.php
@@ -11,13 +11,9 @@ class ImageServeTestCase extends TestCase
     protected $imageSize;
     protected $imageSmallSize;
 
-    if ((!defined('PHP_VERSION_ID')) {
-        $version = explode('.',PHP_VERSION);
-        define('PHP_VERSION_ID', ($version[0] * 10000 + $version[1] * 100 + $version[2]));
-    }
-
-    if(PHP_VERSION_ID <= 70000)
-    {
+        /**
+         * @requires PHP 5.3
+         */
         public function setUp()
         {
             parent::setUp();
@@ -27,6 +23,9 @@ class ImageServeTestCase extends TestCase
             $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
         }
 
+        /**
+         * @requires PHP 5.3
+         */
         public function tearDown()
         {
             $customPath = $this->app['path.public'].'/custom';
@@ -36,7 +35,10 @@ class ImageServeTestCase extends TestCase
 
             parent::tearDown();
         }
-    }else{
+        
+        /**
+         * @requires PHP 7.1
+         */
         public function setUp():void
         {
             parent::setUp();
@@ -45,7 +47,9 @@ class ImageServeTestCase extends TestCase
             $this->imageSize = getimagesize(public_path().$this->imagePath);
             $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
         }
-
+        /**
+         * @requires PHP 7.1
+         */
         public function tearDown():void
         {
             $customPath = $this->app['path.public'].'/custom';

--- a/tests/ImageServeTestCase.php
+++ b/tests/ImageServeTestCase.php
@@ -11,25 +11,51 @@ class ImageServeTestCase extends TestCase
     protected $imageSize;
     protected $imageSmallSize;
 
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->image = $this->app['image'];
-        $this->imageSize = getimagesize(public_path().$this->imagePath);
-        $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
+    if ((!defined('PHP_VERSION_ID')) {
+        $version = explode('.',PHP_VERSION);
+        define('PHP_VERSION_ID', ($version[0] * 10000 + $version[1] * 100 + $version[2]));
     }
 
-    public function tearDown()
+    if(PHP_VERSION_ID <= 70000)
     {
-        $customPath = $this->app['path.public'].'/custom';
-        $this->app['config']->set('image.write_path', $customPath);
+        public function setUp()
+        {
+            parent::setUp();
 
-        $this->image->deleteManipulated($this->imagePath);
+            $this->image = $this->app['image'];
+            $this->imageSize = getimagesize(public_path().$this->imagePath);
+            $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
+        }
 
-        parent::tearDown();
+        public function tearDown()
+        {
+            $customPath = $this->app['path.public'].'/custom';
+            $this->app['config']->set('image.write_path', $customPath);
+
+            $this->image->deleteManipulated($this->imagePath);
+
+            parent::tearDown();
+        }
+    }else{
+        public function setUp():void
+        {
+            parent::setUp();
+
+            $this->image = $this->app['image'];
+            $this->imageSize = getimagesize(public_path().$this->imagePath);
+            $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
+        }
+
+        public function tearDown():void
+        {
+            $customPath = $this->app['path.public'].'/custom';
+            $this->app['config']->set('image.write_path', $customPath);
+
+            $this->image->deleteManipulated($this->imagePath);
+
+            parent::tearDown();
+        }
     }
-
     public function testServeWriteImage()
     {
         $this->app['config']->set('image.write_image', true);

--- a/tests/ImageServeTestCase.php
+++ b/tests/ImageServeTestCase.php
@@ -14,7 +14,7 @@ class ImageServeTestCase extends TestCase
     protected $imageSmallSize;
 
         
-        public function setUp(): void
+        public function setUp():void
         {
             parent::setUp();
 
@@ -23,7 +23,7 @@ class ImageServeTestCase extends TestCase
             $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
         }
 
-        public function tearDown(): void
+        public function tearDown():void
         {
             $customPath = $this->app['path.public'].'/custom';
             $this->app['config']->set('image.write_path', $customPath);

--- a/tests/ImageTestCase.php
+++ b/tests/ImageTestCase.php
@@ -13,7 +13,7 @@ class ImageTestCase extends TestCase
     protected $imageSize;
     protected $imageSmallSize;
 
-        public function setUp()
+        public function setUp(): void
         {
             parent::setUp();
             
@@ -22,7 +22,7 @@ class ImageTestCase extends TestCase
             $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
         }
 
-        public function tearDown()
+        public function tearDown(): void
         {
             $customPath = $this->app['path.public'].'/custom';
             $this->app['config']->set('image.write_path', $customPath);

--- a/tests/ImageTestCase.php
+++ b/tests/ImageTestCase.php
@@ -13,7 +13,7 @@ class ImageTestCase extends TestCase
     protected $imageSize;
     protected $imageSmallSize;
 
-        public function setUp(): void
+        public function setUp():void
         {
             parent::setUp();
             
@@ -22,7 +22,7 @@ class ImageTestCase extends TestCase
             $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
         }
 
-        public function tearDown(): void
+        public function tearDown():void
         {
             $customPath = $this->app['path.public'].'/custom';
             $this->app['config']->set('image.write_path', $customPath);

--- a/tests/ImageTestCase.php
+++ b/tests/ImageTestCase.php
@@ -11,23 +11,50 @@ class ImageTestCase extends TestCase
     protected $imageSize;
     protected $imageSmallSize;
 
-    public function setUp()
-    {
-        parent::setUp();
-        
-        $this->image = $this->app['image'];
-        $this->imageSize = getimagesize(public_path().$this->imagePath);
-        $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
+    if ((!defined('PHP_VERSION_ID')) {
+        $version = explode('.',PHP_VERSION);
+        define('PHP_VERSION_ID', ($version[0] * 10000 + $version[1] * 100 + $version[2]));
     }
 
-    public function tearDown()
+    if(PHP_VERSION_ID <= 70000)
     {
-        $customPath = $this->app['path.public'].'/custom';
-        $this->app['config']->set('image.write_path', $customPath);
-        
-        $this->image->deleteManipulated($this->imagePath);
-        
-        parent::tearDown();
+        public function setUp()
+        {
+            parent::setUp();
+            
+            $this->image = $this->app['image'];
+            $this->imageSize = getimagesize(public_path().$this->imagePath);
+            $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
+        }
+
+        public function tearDown()
+        {
+            $customPath = $this->app['path.public'].'/custom';
+            $this->app['config']->set('image.write_path', $customPath);
+            
+            $this->image->deleteManipulated($this->imagePath);
+            
+            parent::tearDown();
+        }
+    }else{
+        public function setUp():void
+        {
+            parent::setUp();
+            
+            $this->image = $this->app['image'];
+            $this->imageSize = getimagesize(public_path().$this->imagePath);
+            $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
+        }
+
+        public function tearDown():void
+        {
+            $customPath = $this->app['path.public'].'/custom';
+            $this->app['config']->set('image.write_path', $customPath);
+            
+            $this->image->deleteManipulated($this->imagePath);
+            
+            parent::tearDown();
+        }
     }
 
     public function testURLisValid()

--- a/tests/ImageTestCase.php
+++ b/tests/ImageTestCase.php
@@ -1,4 +1,6 @@
-<?php namespace Folklore\Image\Tests;
+<?php 
+declare(strict_types=1);
+namespace Folklore\Image\Tests;
 
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Folklore\Image\Exception\FormatException;
@@ -11,9 +13,6 @@ class ImageTestCase extends TestCase
     protected $imageSize;
     protected $imageSmallSize;
 
-        /**
-         * @requires PHP 5.3
-         */
         public function setUp()
         {
             parent::setUp();
@@ -23,9 +22,6 @@ class ImageTestCase extends TestCase
             $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
         }
 
-        /**
-         * @requires PHP 5.3
-         */
         public function tearDown()
         {
             $customPath = $this->app['path.public'].'/custom';
@@ -36,31 +32,6 @@ class ImageTestCase extends TestCase
             parent::tearDown();
         }
         
-        /**
-         * @requires PHP 7.1
-         */
-        public function setUp():void
-        {
-            parent::setUp();
-            
-            $this->image = $this->app['image'];
-            $this->imageSize = getimagesize(public_path().$this->imagePath);
-            $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
-        }
-
-        /**
-         * @requires PHP 7.1
-         */
-        public function tearDown():void
-        {
-            $customPath = $this->app['path.public'].'/custom';
-            $this->app['config']->set('image.write_path', $customPath);
-            
-            $this->image->deleteManipulated($this->imagePath);
-            
-            parent::tearDown();
-        }
-    }
 
     public function testURLisValid()
     {

--- a/tests/ImageTestCase.php
+++ b/tests/ImageTestCase.php
@@ -11,7 +11,7 @@ class ImageTestCase extends TestCase
     protected $imageSize;
     protected $imageSmallSize;
 
-    public function setUp()
+    public function setUp():void
     {
         parent::setUp();
         
@@ -20,7 +20,7 @@ class ImageTestCase extends TestCase
         $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
     }
 
-    public function tearDown()
+    public function tearDown():void
     {
         $customPath = $this->app['path.public'].'/custom';
         $this->app['config']->set('image.write_path', $customPath);

--- a/tests/ImageTestCase.php
+++ b/tests/ImageTestCase.php
@@ -11,7 +11,7 @@ class ImageTestCase extends TestCase
     protected $imageSize;
     protected $imageSmallSize;
 
-    public function setUp():void
+    public function setUp()
     {
         parent::setUp();
         
@@ -20,7 +20,7 @@ class ImageTestCase extends TestCase
         $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
     }
 
-    public function tearDown():void
+    public function tearDown()
     {
         $customPath = $this->app['path.public'].'/custom';
         $this->app['config']->set('image.write_path', $customPath);

--- a/tests/ImageTestCase.php
+++ b/tests/ImageTestCase.php
@@ -11,13 +11,9 @@ class ImageTestCase extends TestCase
     protected $imageSize;
     protected $imageSmallSize;
 
-    if ((!defined('PHP_VERSION_ID')) {
-        $version = explode('.',PHP_VERSION);
-        define('PHP_VERSION_ID', ($version[0] * 10000 + $version[1] * 100 + $version[2]));
-    }
-
-    if(PHP_VERSION_ID <= 70000)
-    {
+        /**
+         * @requires PHP 5.3
+         */
         public function setUp()
         {
             parent::setUp();
@@ -27,6 +23,9 @@ class ImageTestCase extends TestCase
             $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
         }
 
+        /**
+         * @requires PHP 5.3
+         */
         public function tearDown()
         {
             $customPath = $this->app['path.public'].'/custom';
@@ -36,7 +35,10 @@ class ImageTestCase extends TestCase
             
             parent::tearDown();
         }
-    }else{
+        
+        /**
+         * @requires PHP 7.1
+         */
         public function setUp():void
         {
             parent::setUp();
@@ -46,6 +48,9 @@ class ImageTestCase extends TestCase
             $this->imageSmallSize = getimagesize(public_path().$this->imageSmallPath);
         }
 
+        /**
+         * @requires PHP 7.1
+         */
         public function tearDown():void
         {
             $customPath = $this->app['path.public'].'/custom';


### PR DESCRIPTION
I have test and this work.
The major problem is that Laravel 5.8 requires a php version higher than 7.1, so impossible to roolback in the tests

I think the best will be to let version v0.3.25 for laravel 5.7 and pass on a new version for Laravel 5.8 or higher